### PR TITLE
Fix VETION_REBORN build failure

### DIFF
--- a/src/main/java/com/killsperhour/KphPlugin.java
+++ b/src/main/java/com/killsperhour/KphPlugin.java
@@ -447,7 +447,7 @@ public class KphPlugin extends Plugin
 
                     if (currentNPC.getName() != null && lastValidBoss.getName() != null)
                     {
-                        if(!currentNPC.getName().equals(lastValidBoss.getName()) && lastValidBoss.getId() != NpcID.VETION_REBORN)
+                        if(!currentNPC.getName().equals(lastValidBoss.getName()) && lastValidBoss.getId() != NpcID.VETION_6612)
                         {
                             attkCount = 1;
                             setKillTimeStart();
@@ -498,7 +498,7 @@ public class KphPlugin extends Plugin
         {
             if(lastValidBoss.isDead() && stoper == 0)
             {
-                if(lastValidBoss.getId() != NpcID.KALPHITE_QUEEN_963 && lastValidBoss.getId() != NpcID.VETION_REBORN )
+                if(lastValidBoss.getId() != NpcID.KALPHITE_QUEEN_963 && lastValidBoss.getId() != NpcID.VETION_6612 )
                 {
                     sMethods.dagTimeClearTwo();
                     attkCount = 0;


### PR DESCRIPTION
VETION_REBORN has been renamed to VETION_6612 as can be seen in https://github.com/runelite/runelite/commit/fe69c4687d667c0ad92fea113e304c7c2f3bbdf2 Haven't tested anything ingame and I'm not familiar with the code base, so I don't know if the plugin is functional for any of the wildy bosses or their baby counterparts. However, this should make the plugin build again so it can be used again.

Fixes #7 