### PR TITLE
Added the ability to end a session when the player enters a PoH

### DIFF
--- a/src/main/java/com/killsperhour/KphConfig.java
+++ b/src/main/java/com/killsperhour/KphConfig.java
@@ -254,9 +254,17 @@ public interface KphConfig extends Config
     )
     default boolean printKphInChat() { return false; }
 
+    @ConfigItem(
+        position = 5,
+        keyName = "PoH Ends Session",
+        name = "PoH Ends Session",
+        description = "Automatically ends the current session when the player enters the PoH",
+        section = generalSettings
+    )
+    default boolean endSessionPoH() { return false; }
 
     @ConfigItem(
-            position = 5,
+            position = 6,
             keyName = "Session Timeout",
             name = "Session Timeout",
             description = "Set the session timeout time in minutes (set to 0 for no timeout time)",
@@ -276,7 +284,7 @@ public interface KphConfig extends Config
     }
 
     @ConfigItem(
-            position = 6,
+            position = 7,
             keyName = "KPH Calc Method",
             name = "KPH Calc",
             description = "Allows you to choose the method KPH calculated via",
@@ -291,7 +299,7 @@ public interface KphConfig extends Config
     }
 
     @ConfigItem(
-            position = 7,
+            position = 8,
             keyName = "Loot Display",
             name = "Loot Display",
             description = "Allows you to choose the method KPH calculated via",
@@ -308,7 +316,7 @@ public interface KphConfig extends Config
     }
 
     @ConfigItem(
-            position = 8,
+            position = 9,
             keyName = "Dagannoth Selector",
             name = "Dagannoth Selector",
             description = "Allows you to select which Dagannoth King the plugin will track",

--- a/src/main/java/com/killsperhour/KphPlugin.java
+++ b/src/main/java/com/killsperhour/KphPlugin.java
@@ -28,10 +28,7 @@ import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.*;
-import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GameTick;
-import net.runelite.api.events.HitsplatApplied;
+import net.runelite.api.events.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatCommandManager;
 import net.runelite.client.chat.ChatMessageManager;
@@ -143,6 +140,8 @@ public class KphPlugin extends Plugin
     private int pauseTime;
     private int firstKillTime;
     private int attkCount;
+
+    private final int pohPortalId = ObjectID.PORTAL_4525;
 
     private final int[] cmRegions = {13138, 13137, 13139, 13141, 13136, 13145, 13393, 13394, 13140, 13395, 13397};
     private final int[] regGauntletRegion = {7512};
@@ -574,8 +573,19 @@ public class KphPlugin extends Plugin
 
     }
 
-
-
+    @Subscribe
+    public void onGameObjectSpawned(GameObjectSpawned event)
+    {
+        // Retrieve the spawned object
+        final GameObject gameObject = event.getGameObject();
+        // Try and see if the PoH exit portal is found (id PORTAL_4525) if it is that means the player is in a PoH
+        if (gameObject.getId() == pohPortalId)
+        {
+            // The player is in a PoH. Check to see if they want to end session when in PoH
+            if (config.endSessionPoH())
+                sessionEnd();
+        }
+    }
 
     public boolean timesAreNotNull()
     {


### PR DESCRIPTION
New configurable option that allows the player to choose if the session should be ended when they teleport/enter a Player Owned House. This is useful for anyone using the plugin to track how many kills they're getting in a trip rather then Kills Per Hour.