### PR TITLE
Bandaid fixes to solve issues with sidepanel disabled.

### DIFF
--- a/src/main/java/com/killsperhour/KphPanel.java
+++ b/src/main/java/com/killsperhour/KphPanel.java
@@ -334,7 +334,7 @@ class KphPanel extends PluginPanel {
 
     public void updateLootHeaderInfo(int kills, double Kph)
     {
-        FontMetrics fontMetrics = getGraphics().getFontMetrics(FontManager.getRunescapeSmallFont());
+        FontMetrics fontMetrics = getFontMetrics(FontManager.getRunescapeSmallFont());
         totalGpLabel.setText(htmlLabel("Total Gp: ",doubleFormatNumber(fileRW.totalGp)));
         gpPerHourLabel.setText(htmlLabel("GP/Hr: ",doubleFormatNumber(convertToGpPerHour(kills,Kph))));
         gpPerKill.setText(htmlLabel("GP/Kill: ",doubleFormatNumber(convertToGpPerKill(kills))));
@@ -662,7 +662,7 @@ class KphPanel extends PluginPanel {
 
         int length;
 
-        FontMetrics fontMetrics = getGraphics().getFontMetrics(FontManager.getRunescapeSmallFont());
+        FontMetrics fontMetrics = getFontMetrics(FontManager.getRunescapeSmallFont());
         boolean killsDoneIsLonger = (fontMetrics.stringWidth(killsLeftLabel.getText()) < fontMetrics.stringWidth(killsDoneLabel.getText()));
 
         if(killsDoneIsLonger){length = fontMetrics.stringWidth(killsDoneLabel.getText());}
@@ -861,7 +861,7 @@ class KphPanel extends PluginPanel {
 
         }
 
-        FontMetrics fontMetrics = getGraphics().getFontMetrics(FontManager.getRunescapeBoldFont());
+        FontMetrics fontMetrics = getFontMetrics(FontManager.getRunescapeBoldFont());
         int offset = 180 - (fontMetrics.stringWidth(fetchedBossName.getText()) + 10);
                                                         //if i chan
         fetchedIcon.setBorder(new EmptyBorder(0, 0, 0,offset));
@@ -1312,7 +1312,7 @@ class KphPanel extends PluginPanel {
         {
             KphBossInfo kphBossInfo = KphBossInfo.find(bossName);
             AsyncBufferedImage bossSprite = itemManager.getImage(kphBossInfo.getIcon());
-            FontMetrics fontMetrics = getGraphics().getFontMetrics(FontManager.getRunescapeBoldFont());
+            FontMetrics fontMetrics = getFontMetrics(FontManager.getRunescapeBoldFont());
             int offset = 150 - (fontMetrics.stringWidth(plugin.sessionNpc) + 10);
             icon.setBorder(new EmptyBorder(0, 0, 153,offset));
             bossSprite.addTo(picLabel);

--- a/src/main/java/com/killsperhour/KphPlugin.java
+++ b/src/main/java/com/killsperhour/KphPlugin.java
@@ -248,7 +248,7 @@ public class KphPlugin extends Plugin
             case "Side Panel":
                 if(config.showSidePanel())
                 {
-                    buildSidePanel();
+					clientToolbar.addNavigation(navButton);
                 }
                 else
                 {
@@ -627,11 +627,13 @@ public class KphPlugin extends Plugin
 
     private void buildSidePanel()
     {
-        panel = (KphPanel) injector.getInstance(KphPanel.class);
+        panel = injector.getInstance(KphPanel.class);
         panel.sidePanelInitializer();
         icon = ImageUtil.loadImageResource(getClass(), "/icon.png");
         navButton = NavigationButton.builder().tooltip("Bossing Info").icon(icon).priority(config.sidePanelPosition()).panel(panel).build();
-        clientToolbar.addNavigation(navButton);
+		if (config.showSidePanel()){
+			clientToolbar.addNavigation(navButton);
+		}
     }
 
 
@@ -1567,10 +1569,7 @@ public class KphPlugin extends Plugin
         chatCommandManager.registerCommandAsync("!Pause", this::pauseCommand);
         chatCommandManager.registerCommandAsync("!Resume", this::resumeCommand);
 
-        if(config.showSidePanel())
-        {
-            buildSidePanel();
-        }
+		buildSidePanel();
 
         //take idle time into account
         calcMode = 0;


### PR DESCRIPTION
### Symptom

1. Overlay displays the wrong number of kills with the side panel disabled.
2. The overlay always displays 2 kills upon the first kill with the side panel disabled.

### Problem

1. `KphPlugin::totalSessionTimer()` crashes due to a NullPointerError on calling `panel.setSessionTimeLabel()`.
2. `KphPanel::setBossMetrics()` crashes due to the graphics not existing on `FontMetrics fontMetrics = getGraphics().getFontMetrics(FontManager.getRunescapeBoldFont())`.

### Solution

1. Instead of only creating the panel when the config option is enabled, create the panel regardless and hide it if the option is disabled.
2. Remove call to graphics to get font metrics, because it is a hardcoded font.